### PR TITLE
[ci] Update openwisp-utils and migrate to common CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ env:
 before_install:
   - pip install -e git+https://github.com/openwisp/django-ipam#egg=django-ipam
   - pip install --no-cache-dir -U -r requirements-test.txt
-  - ./runcheckmigration
-  - flake8
-  - isort --check-only --recursive --diff .
+  - openwisp-utils-qa-checks --migration-path ./openwisp_ipam/migrations/
 
 install:
   - pip install "django>=2.0,<2.1"
@@ -29,14 +27,6 @@ install:
 script:
   - coverage run --source=openwisp_ipam runtests.py
   - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then ./tests/manage.py makemigrations openwisp_ipam --dry-run | grep "No changes detected"; fi
-  - |
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-      # gets commit message of last commit before pull request merge
-      COMMIT_MESSAGE=$(git log $TRAVIS_PULL_REQUEST_SHA --format=%B -n 1)
-      printf "Checking commit message:\n\n"
-      printf "$COMMIT_MESSAGE\n\n"
-      checkcommit --message "$COMMIT_MESSAGE"
-    fi
 
 after_success:
   - coveralls

--- a/openwisp_ipam/admin.py
+++ b/openwisp_ipam/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from openwisp_utils.admin import MultitenantAdminMixin
+from openwisp_users.multitenancy import MultitenantAdminMixin
 
 from django_ipam.base.admin import AbstractIpAddressAdmin, AbstractSubnetAdmin
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 coverage
 coveralls
 django-extensions>=2.0.7
-openwisp-utils[qa]>=0.2.1
+openwisp-utils[qa]>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-openwisp-users>=0.1.8,<0.2
-openwisp-utils>=0.2.1,< 0.3
+openwisp-users>=0.1.11,<0.2
+openwisp-utils>=0.3,<0.4
 django>=1.11,<2.1
 swapper>=1.1.0
 djangorestframework>=3.7,<3.9

--- a/runcheckmigration
+++ b/runcheckmigration
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -e
-checkmigrations --migration-path ./openwisp_ipam/migrations/ || exit 1


### PR DESCRIPTION
Update requirements and fix import issues because openwisp-utils 0.3 now move the multitenancy feature to openwisp-users 0.1.11. Also change travis script to run common CI and remove unnecessary script.