### PR TITLE
[Deps] Dropped Python 3.5; Added Python 3.6, 3.7 on Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ dist: bionic
 cache: pip
 
 python:
-  - "3.5"
+  - "3.6"
+  - "3.7"
 
 branches:
   only:


### PR DESCRIPTION
Modified Travis yml file by dropping Python 3.5 support and Adding Python 3.6 and 3.7 .
Fixes #21