### PR TITLE
[subnet-visualizer] Adding support for updated urls in django-ipam

### DIFF
--- a/openwisp_ipam/urls.py
+++ b/openwisp_ipam/urls.py
@@ -6,4 +6,5 @@ app_name = 'ipam'
 urlpatterns = [
     url(r'^api/v1/', include(api)),
     url(r'^accounts/', include('openwisp_users.accounts.urls')),
+    url(r'^', include('django_ipam.api.urls')),
 ]


### PR DESCRIPTION
Related to issue #24
This adds support for urls.py update in django-ipam.
Prior to it:
The exact traceback in Travis was: 
```
File "/home/travis/virtualenv/python3.6.10/src/django-ipam/django_ipam/tests/base/test_api.py", line 199, in test_hosts_list_api
  response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
File "/home/travis/virtualenv/python3.6.10/lib/python3.6/site-packages/django/urls/base.py", line 90, in reverse
  return iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs))
File "/home/travis/virtualenv/python3.6.10/lib/python3.6/site-packages/django/urls/resolvers.py", line 673, in _reverse_with_prefix
  raise NoReverseMatch(msg)
django.urls.exceptions.NoReverseMatch: Reverse for 'hosts' not found. 'hosts' is not a valid view function or pattern name.
```
This is related to [PR #89](https://github.com/openwisp/django-ipam/pull/89/files#) of django-ipam and commits following it.