### PR TITLE
[docs] Fixed image rendering on README #67

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,14 +131,14 @@ REST API
 Live documentation
 ==================
 
-.. image:: https://github.com/openwisp/openwisp-ipam/raw/master/docs/images/api-docs.png
+.. image:: https://github.com/openwisp/openwisp-ipam/raw/master/docs/api-docs.png
 
 A general live API documentation (following the OpenAPI specification) is available at ``/api/v1/docs/``.
 
 Browsable web interface
 =======================
 
-.. image:: https://github.com/openwisp/openwisp-ipam/raw/master/docs/images/api-ui.png
+.. image:: https://github.com/openwisp/openwisp-ipam/raw/master/docs/api-ui.png
 
 Additionally, opening any of the endpoints `listed below <#list-of-endpoints>`_
 directly in the browser will show the `browsable API interface of Django-REST-Framework


### PR DESCRIPTION
Changed the URL for the images in the rest api section to load all the
images correctly in README.

Fixes #67