### PR TITLE
[fix] Fixed creation of subnet without name #131

### DIFF
--- a/openwisp_ipam/base/models.py
+++ b/openwisp_ipam/base/models.py
@@ -21,7 +21,7 @@ class CsvImportException(Exception):
 
 
 class AbstractSubnet(ShareableOrgMixin, TimeStampedEditableModel):
-    name = models.CharField(max_length=100, blank=True, db_index=True)
+    name = models.CharField(max_length=100, db_index=True)
     subnet = NetworkField(
         db_index=True,
         help_text=_(
@@ -44,9 +44,7 @@ class AbstractSubnet(ShareableOrgMixin, TimeStampedEditableModel):
         unique_together = ('subnet', 'organization')
 
     def __str__(self):
-        if self.name:
-            return f'{self.name} {self.subnet}'
-        return str(self.subnet)
+        return f'{self.name} {self.subnet}'
 
     def clean(self):
         if not self.subnet:

--- a/openwisp_ipam/migrations/0001_initial.py
+++ b/openwisp_ipam/migrations/0001_initial.py
@@ -97,7 +97,7 @@ class Migration(migrations.Migration):
                         verbose_name='modified',
                     ),
                 ),
-                ('name', models.CharField(blank=True, db_index=True, max_length=100)),
+                ('name', models.CharField(db_index=True, max_length=100)),
                 (
                     'subnet',
                     openwisp_ipam.base.fields.NetworkField(

--- a/openwisp_ipam/tests/__init__.py
+++ b/openwisp_ipam/tests/__init__.py
@@ -23,6 +23,7 @@ class CreateModelsMixin(TestOrganizationMixin):
 
     def _create_subnet(self, **kwargs):
         options = dict(
+            name='test subnet',
             subnet='',
             description='',
         )

--- a/openwisp_ipam/tests/test_api.py
+++ b/openwisp_ipam/tests/test_api.py
@@ -104,7 +104,9 @@ class TestApi(TestMultitenantAdminMixin, CreateModelsMixin, PostDataMixin, TestC
         self.assertEqual(response.data, None)
 
     def test_create_subnet_api(self):
-        post_data = self._post_data(subnet='10.0.0.0/32', description='Testing')
+        post_data = self._post_data(
+            name='Subnet', subnet='10.0.0.0/32', description='Testing'
+        )
         response = self.client.post(
             reverse('ipam:subnet_list_create'),
             data=post_data,

--- a/openwisp_ipam/tests/test_models.py
+++ b/openwisp_ipam/tests/test_models.py
@@ -108,10 +108,6 @@ class TestModels(CreateModelsMixin, TestCase):
         ipaddr = subnet.request_ip()
         self.assertEqual(ipaddr, None)
 
-    def test_subnet_string_representation(self):
-        subnet = Subnet(subnet='entry subnet')
-        self.assertEqual(str(subnet), str(subnet.subnet))
-
     def test_subnet_string_representation_with_name(self):
         subnet = Subnet(subnet='entry subnet', name='test1')
         self.assertEqual(str(subnet), '{0} {1}'.format(subnet.name, str(subnet.subnet)))
@@ -310,6 +306,22 @@ class TestModels(CreateModelsMixin, TestCase):
             self.assertTrue(
                 err.message_dict['subnet'] == ['This field cannot be blank.']
             )
+        else:
+            self.fail('ValidationError not raised')
+
+    def test_save_none_subnet_name_fails(self):
+        try:
+            self._create_subnet(name=None)
+        except ValidationError as err:
+            self.assertTrue(err.message_dict['name'] == ['This field cannot be null.'])
+        else:
+            self.fail('ValidationError not raised')
+
+    def test_save_blank_subnet_name_fails(self):
+        try:
+            self._create_subnet(name='')
+        except ValidationError as err:
+            self.assertTrue(err.message_dict['name'] == ['This field cannot be blank.'])
         else:
             self.fail('ValidationError not raised')
 

--- a/openwisp_ipam/tests/test_multitenant.py
+++ b/openwisp_ipam/tests/test_multitenant.py
@@ -50,8 +50,8 @@ class TestMultitenantAdmin(TestMultitenantAdminMixin, CreateModelsMixin, TestCas
         data = self._create_multitenancy_test_env()
         self._test_multitenant_admin(
             url=reverse(f'admin:{self.app_label}_subnet_changelist'),
-            visible=[data['subnet1']],
-            hidden=[data['subnet2']],
+            visible=[data['subnet1'].subnet],
+            hidden=[data['subnet2'].subnet],
         )
 
     def test_import_subnet_permission(self):

--- a/tests/openwisp2/sample_ipam/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_ipam/migrations/0001_initial.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
                         verbose_name='modified',
                     ),
                 ),
-                ('name', models.CharField(blank=True, db_index=True, max_length=100)),
+                ('name', models.CharField(db_index=True, max_length=100)),
                 (
                     'subnet',
                     openwisp_ipam.base.fields.NetworkField(


### PR DESCRIPTION
- Updated the **name field** of the `Subnet` model to not be blank.
- Updated `__str__` of `AbstractSubnet` model.
- Updated `test_multitenancy_subnet_queryset`, `test_create_subnet_api`.
- Added `test_save_none_subnet_fails`, `test_save_blank_subnet_fails`.
- Removed redundant `test_subnet_string_representation`.

Fixes #131

### `BEFORE`  :
#### (See, subnets become inaccessible from the `changelist view`) 

![Screenshot from 2022-02-19 23-32-32](https://user-images.githubusercontent.com/56113566/154816706-dac7dd1a-b4b0-4f45-a165-e8dea99b74ba.png)

### Now

![Screenshot from 2022-02-19 23-32-55](https://user-images.githubusercontent.com/56113566/154816708-5106d605-65c9-49c7-a98d-dc29d5902583.png)



