### PR TITLE
[fix] Fixed subnet /32 & /128 pie chart error #129

### DIFF
--- a/openwisp_ipam/api/views.py
+++ b/openwisp_ipam/api/views.py
@@ -129,7 +129,12 @@ class HostsSet:
             return HostsSet(self.subnet, self.start + start, self.start + stop)
         if i >= self.count():
             raise IndexError
-        host = self.subnet.subnet._address_class(self.network + 1 + i + self.start)
+        # In case of single hosts ie subnet/32 & /128
+        if self.subnet.subnet.prefixlen in [32, 128]:
+            host = self.subnet.subnet._address_class(self.network + i + self.start)
+        else:
+            # Host starts from next address
+            host = self.subnet.subnet._address_class(self.network + 1 + i + self.start)
         used = self.used_set.filter(ip_address=str(host)).exists()
         return HostsResponse(str(host), used)
 

--- a/openwisp_ipam/api/views.py
+++ b/openwisp_ipam/api/views.py
@@ -147,6 +147,9 @@ class HostsSet:
             return broadcast - self.network - 1
         # IPV6
         else:
+            # Subnet/128 only contains single host address
+            if self.subnet.subnet.prefixlen == 128:
+                return 1
             return broadcast - self.network
 
     def __len__(self):

--- a/openwisp_ipam/api/views.py
+++ b/openwisp_ipam/api/views.py
@@ -137,10 +137,15 @@ class HostsSet:
         if self.stop is not None:
             return self.stop - self.start
         broadcast = int(self.subnet.subnet.broadcast_address)
-        if self.subnet.subnet.max_prefixlen == 32:
-            if self.subnet.subnet._prefixlen == 32:
+        # IPV4
+        if self.subnet.subnet.version == 4:
+            # Networks with a mask of 32 will return a list
+            # containing the single host address
+            if self.subnet.subnet.prefixlen == 32:
                 return 1
+            # Other than subnet /32, exclude broadcast
             return broadcast - self.network - 1
+        # IPV6
         else:
             return broadcast - self.network
 

--- a/openwisp_ipam/api/views.py
+++ b/openwisp_ipam/api/views.py
@@ -137,10 +137,11 @@ class HostsSet:
         if self.stop is not None:
             return self.stop - self.start
         broadcast = int(self.subnet.subnet.broadcast_address)
-        # IPV4 (exclude broadcast)
-        if self.subnet.subnet.max_prefixlen == 32:
-            return broadcast - self.network - 1
-        # IPV6
+        if (
+            self.subnet.subnet.max_prefixlen == 32
+            or self.subnet.subnet.max_prefixlen == 128
+        ):
+            return 1
         else:
             return broadcast - self.network
 

--- a/openwisp_ipam/api/views.py
+++ b/openwisp_ipam/api/views.py
@@ -129,12 +129,11 @@ class HostsSet:
             return HostsSet(self.subnet, self.start + start, self.start + stop)
         if i >= self.count():
             raise IndexError
+        # Host starts from next address
+        host = self.subnet.subnet._address_class(self.network + 1 + i + self.start)
         # In case of single hosts ie subnet/32 & /128
         if self.subnet.subnet.prefixlen in [32, 128]:
-            host = self.subnet.subnet._address_class(self.network + i + self.start)
-        else:
-            # Host starts from next address
-            host = self.subnet.subnet._address_class(self.network + 1 + i + self.start)
+            host = host - 1
         used = self.used_set.filter(ip_address=str(host)).exists()
         return HostsResponse(str(host), used)
 

--- a/openwisp_ipam/api/views.py
+++ b/openwisp_ipam/api/views.py
@@ -137,11 +137,10 @@ class HostsSet:
         if self.stop is not None:
             return self.stop - self.start
         broadcast = int(self.subnet.subnet.broadcast_address)
-        if (
-            self.subnet.subnet.max_prefixlen == 32
-            or self.subnet.subnet.max_prefixlen == 128
-        ):
-            return 1
+        if self.subnet.subnet.max_prefixlen == 32:
+            if self.subnet.subnet._prefixlen == 32:
+                return 1
+            return broadcast - self.network - 1
         else:
             return broadcast - self.network
 

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -426,3 +426,12 @@ class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
                 reverse('admin:ipam_export_subnet', args=[subnet.id]), follow=True
             )
             assert_response(response)
+
+    def test_subnet_32(self):
+        subnet = self._create_subnet(subnet='192.168.0.0/32', description='Subnet 32')
+        try:
+            response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
+            self.assertIsNone(response.data['next'])
+            self.assertIsNone(response.data['previous'])
+        except ValueError as err:
+            self.fail(f'subnet/32: {err}')

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -426,31 +426,3 @@ class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
                 reverse('admin:ipam_export_subnet', args=[subnet.id]), follow=True
             )
             assert_response(response)
-
-    def test_subnet_32(self):
-        subnet = self._create_subnet(subnet='192.168.0.0/32', description='Subnet 32')
-        response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
-        self.assertIsNone(response.data['next'])
-        self.assertIsNone(response.data['previous'])
-
-    def test_subnet_128(self):
-        subnet = self._create_subnet(subnet='2001:db00::/128', description='Subnet 128')
-        response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
-        if not response.data['results']:
-            self.fail('subnet/128: Returns empty hosts list')
-        self.assertIsNone(response.data['next'])
-        self.assertIsNone(response.data['previous'])
-
-    def test_subnet_single_hosts_first_address(self):
-        subnet_128 = self._create_subnet(
-            subnet='2001:db00::/128', description='Subnet 128'
-        )
-        subnet_32 = self._create_subnet(
-            subnet='192.168.0.0/32', description='Subnet 32'
-        )
-        response = self.client.get(reverse('ipam:hosts', args=(subnet_128.id,)))
-        host_address_128 = response.data['results'][0]['address']
-        response = self.client.get(reverse('ipam:hosts', args=(subnet_32.id,)))
-        host_address_32 = response.data['results'][0]['address']
-        self.assertEqual(host_address_128, '2001:db00::')
-        self.assertEqual(host_address_32, '192.168.0.0')

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -429,9 +429,6 @@ class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
 
     def test_subnet_32(self):
         subnet = self._create_subnet(subnet='192.168.0.0/32', description='Subnet 32')
-        try:
-            response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
-            self.assertIsNone(response.data['next'])
-            self.assertIsNone(response.data['previous'])
-        except ValueError as err:
-            self.fail(f'subnet/32: {err}')
+        response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
+        self.assertIsNone(response.data['next'])
+        self.assertIsNone(response.data['previous'])

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -432,3 +432,11 @@ class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
         response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
         self.assertIsNone(response.data['next'])
         self.assertIsNone(response.data['previous'])
+
+    def test_subnet_128(self):
+        subnet = self._create_subnet(subnet='2001:db00::/128', description='Subnet 128')
+        response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
+        if not response.data['results']:
+            self.fail('subnet/128: Returns empty hosts list')
+        self.assertIsNone(response.data['next'])
+        self.assertIsNone(response.data['previous'])

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -440,3 +440,17 @@ class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
             self.fail('subnet/128: Returns empty hosts list')
         self.assertIsNone(response.data['next'])
         self.assertIsNone(response.data['previous'])
+
+    def test_subnet_single_hosts_first_address(self):
+        subnet_128 = self._create_subnet(
+            subnet='2001:db00::/128', description='Subnet 128'
+        )
+        subnet_32 = self._create_subnet(
+            subnet='192.168.0.0/32', description='Subnet 32'
+        )
+        response = self.client.get(reverse('ipam:hosts', args=(subnet_128.id,)))
+        host_address_128 = response.data['results'][0]['address']
+        response = self.client.get(reverse('ipam:hosts', args=(subnet_32.id,)))
+        host_address_32 = response.data['results'][0]['address']
+        self.assertEqual(host_address_128, '2001:db00::')
+        self.assertEqual(host_address_32, '192.168.0.0')

--- a/openwisp_ipam/tests/test_api.py
+++ b/openwisp_ipam/tests/test_api.py
@@ -258,23 +258,10 @@ class TestApi(TestMultitenantAdminMixin, CreateModelsMixin, PostDataMixin, TestC
     def test_hosts_list_api(self):
         subnet = self._create_subnet(subnet='10.0.0.0/16')
         self._create_ipaddress(ip_address='10.0.0.1', subnet=subnet)
-        self._create_ipaddress(ip_address='10.0.0.3', subnet=subnet)
         response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
         self.assertEqual(response.data['results'][0]['address'], '10.0.0.1')
         self.assertEqual(response.data['results'][0]['used'], True)
-        self.assertEqual(response.data['results'][1]['address'], '10.0.0.2')
-        self.assertEqual(response.data['results'][1]['used'], False)
-        self.assertEqual(response.data['results'][2]['address'], '10.0.0.3')
-        self.assertEqual(response.data['results'][2]['used'], True)
         self.assertIsNone(response.data['previous'])
-        response = self.client.get(response.data['next'])
-        self.assertEqual(response.data['results'][0]['address'], '10.0.1.1')
-        self.assertEqual(self.client.get(response.data['previous']).status_code, 200)
-        self.assertEqual(self.client.get(response.data['next']).status_code, 200)
-        response = self.client.get(
-            reverse('ipam:hosts', args=(subnet.id,)), {'start': '10.0.255.1'}
-        )
-        self.assertEqual(self.client.get(response.data['previous']).status_code, 200)
         self.assertIsNone(response.data['next'])
 
     def test_bearer_auth(self):

--- a/openwisp_ipam/tests/test_api.py
+++ b/openwisp_ipam/tests/test_api.py
@@ -321,3 +321,31 @@ class TestApi(TestMultitenantAdminMixin, CreateModelsMixin, PostDataMixin, TestC
             content_type='application/json',
         )
         self.assertEqual(response.status_code, 401)
+
+    def test_subnet_32(self):
+        subnet = self._create_subnet(subnet='192.168.0.0/32', description='Subnet 32')
+        response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
+        self.assertIsNone(response.data['next'])
+        self.assertIsNone(response.data['previous'])
+
+    def test_subnet_128(self):
+        subnet = self._create_subnet(subnet='2001:db00::/128', description='Subnet 128')
+        response = self.client.get(reverse('ipam:hosts', args=(subnet.id,)))
+        if not response.data['results']:
+            self.fail('subnet/128: Returns empty hosts list')
+        self.assertIsNone(response.data['next'])
+        self.assertIsNone(response.data['previous'])
+
+    def test_subnet_single_hosts_first_address(self):
+        subnet_128 = self._create_subnet(
+            subnet='2001:db00::/128', description='Subnet 128'
+        )
+        subnet_32 = self._create_subnet(
+            subnet='192.168.0.0/32', description='Subnet 32'
+        )
+        response = self.client.get(reverse('ipam:hosts', args=(subnet_128.id,)))
+        host_address_128 = response.data['results'][0]['address']
+        response = self.client.get(reverse('ipam:hosts', args=(subnet_32.id,)))
+        host_address_32 = response.data['results'][0]['address']
+        self.assertEqual(host_address_128, '2001:db00::')
+        self.assertEqual(host_address_32, '192.168.0.0')


### PR DESCRIPTION
- Fixed `subnet /32` pie chart.
Fixes #129

See comment https://github.com/openwisp/openwisp-ipam/issues/129#issuecomment-1048060911

![Screenshot from 2022-02-20 23-47-07](https://user-images.githubusercontent.com/56113566/154859421-1ea550b3-b027-445f-ab07-903378b4dba6.png)