### PR TITLE
[fix] Added error handling in Subnet admin change view

### DIFF
--- a/openwisp_ipam/admin.py
+++ b/openwisp_ipam/admin.py
@@ -55,6 +55,9 @@ class SubnetAdmin(
     def change_view(self, request, object_id, form_url='', extra_context=None):
         instance = self.get_object(request, object_id)
         if instance is None:
+            # This is an internal Django method that redirects the
+            # user to the admin index page with a message that points
+            # out that the requested object does not exist.
             return self._get_obj_does_not_exist_redirect(
                 request, self.model._meta, object_id
             )

--- a/openwisp_ipam/admin.py
+++ b/openwisp_ipam/admin.py
@@ -53,7 +53,11 @@ class SubnetAdmin(
     save_on_top = True
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
-        instance = Subnet.objects.get(pk=object_id)
+        instance = self.get_object(request, object_id)
+        if instance is None:
+            return self._get_obj_does_not_exist_redirect(
+                request, self.model._meta, object_id
+            )
         ipaddress_add_url = 'admin:{0}_ipaddress_add'.format(self.app_label)
         ipaddress_change_url = 'admin:{0}_ipaddress_change'.format(self.app_label)
         subnet_change_url = 'admin:{0}_subnet_change'.format(self.app_label)

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -23,6 +23,18 @@ class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
         )
         self.client.login(username='admin', password='tester')
 
+    def test_non_existing_subnet_change_view(self):
+        id = '00000000-0000-0000-0000-0000000000000'
+        response = self.client.post(
+            reverse(f'admin:{self.app_label}_subnet_change', args=[id]), follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            f'Subnet with ID “{id}” doesn’t exist. Perhaps it was deleted?',
+            html=True,
+        )
+
     def test_ipaddress_invalid_entry(self):
         subnet = self._create_subnet(subnet='10.0.0.0/24', description='Sample Subnet')
         post_data = self._post_data(


### PR DESCRIPTION
Bug:
Accessing admin change view of a non-existent subnet object
resulted in Server Error 500 because the "DoesNotExist"
conditioned was not handled.