### PR TITLE
[fix] Prevent IPv4 subnet creation from IPv6 master subnet #154

### DIFF
--- a/openwisp_ipam/base/models.py
+++ b/openwisp_ipam/base/models.py
@@ -136,6 +136,18 @@ class AbstractSubnet(ShareableOrgMixin, TimeStampedEditableModel):
     def _validate_master_subnet_consistency(self):
         if not self.master_subnet:
             return
+        subnet_version = ip_network(self.subnet).version
+        master_subnet_version = ip_network(self.master_subnet.subnet).version
+        if subnet_version != master_subnet_version:
+            raise ValidationError(
+                {
+                    'master_subnet': _(
+                        f'IP version mismatch: Subnet {self.subnet} is IPv'
+                        f'{subnet_version}, but Master Subnet '
+                        f'{self.master_subnet.subnet} is IPv{master_subnet_version}.'
+                    )
+                }
+            )
         if not ip_network(self.subnet).subnet_of(ip_network(self.master_subnet.subnet)):
             raise ValidationError({'master_subnet': _('Invalid master subnet.')})
 


### PR DESCRIPTION
Added validation to restrict creating an IPv4 subnet under an IPv6 master subnet. Now, the UI displays an appropriate error message instead of a server error.

Fixes #154

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Reference to Existing Issue

Closes #154

## Description of Changes

Created a new validation check for version mismatch and previously there was a test case for checking the internal server error, so updated that test case to check the validation error.

## Screenshot

![image](https://github.com/user-attachments/assets/e9cdd496-f85d-47e8-bf7a-d8b55a10c874)
