### PR TITLE
[base] Fix hierarchical duplicate IP validation #116

### DIFF
--- a/openwisp_ipam/tests/test_hierarchy_validation.py
+++ b/openwisp_ipam/tests/test_hierarchy_validation.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+from openwisp_ipam.models import Subnet, IpAddress
+
+class HierarchyTest(TestCase):
+    def test_hierarchy_duplicate(self):
+        parent = Subnet.objects.create(name='parent',subnet ="10.0.0.0/16")
+        child = Subnet.objects.create(name='child',subnet="10.0.1.0/24")
+
+        IpAddress.objects.create(ip_address="10.0.1.10", subnet=child)
+
+        with self.assertRaises(ValidationError):
+            obj=IpAddress(ip_address="10.0.1.10", subnet=parent)
+            obj.full_clean()
+            obj.save()


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #116 .


## Description of Changes

Previously, AbstractIpAddress.clean() only checked for duplicate IP addresses within the same subnet.
As discussed in issue #116, this allows invalid configurations where:

An IP exists in a child subnet, and
The same IP is created again in a parent subnet.

This PR introduces hierarchical subnet duplicate detection by:

1. Identifying all related subnets

2. A subnet is considered related if its network contains the IP being validated.
This includes:
- Parent subnets
- Child subnets
- Overlapping subnets
- The subnet itself


3. Validating duplicates across all related subnets

If the same IP exists in any related subnet, a ValidationError is raised.




