### PR TITLE
[admin/ipam] Add export all subnets CSV action #104

### DIFF
--- a/openwisp_ipam/templates/admin/openwisp-ipam/subnet/change_list.html
+++ b/openwisp_ipam/templates/admin/openwisp-ipam/subnet/change_list.html
@@ -8,6 +8,11 @@
     {% trans 'Import Subnet' %}
   </a>
 </li>
+<li>
+  <a href="{% url 'admin:ipam_export_all_subnets' %}">
+    {% trans 'Export Subnets' %}
+  </a>
+</li>
 {% endif %}
 {{ block.super }}
 {% endblock %}

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -329,6 +329,32 @@ class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
         response = self.client.get(reverse("admin:ipam_import_subnet"))
         self.assertEqual(response.status_code, 200)
 
+    def test_export_all_subnet_csv(self):
+        subnet1 = self._create_subnet(subnet="10.0.0.0/24", name="Subnet One")
+        self._create_ipaddress(ip_address="10.0.0.1", subnet=subnet1, description="Router")
+        subnet2 = self._create_subnet(subnet="192.168.1.0/24", name="Subnet Two")
+        self._create_ipaddress(ip_address="192.168.1.1", subnet=subnet2, description="Printer")
+        
+        csv_data = (
+            "Subnet One\r\n"
+            "10.0.0.0/24\r\n"
+            "test-org\r\n"
+            "\r\n"
+            "ip_address,description\r\n"
+            "10.0.0.1,Router\r\n"
+            "\r\n"
+            "Subnet Two\r\n"
+            "192.168.1.0/24\r\n"
+            "test-org\r\n"
+            "\r\n"
+            "ip_address,description\r\n"
+            "192.168.1.1,Printer\r\n"
+        ).encode("utf-8")
+        url = reverse("admin:ipam_export_all_subnets")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, csv_data)
+
     def test_hierarchy_tree(self):
         subnet_root = self._create_subnet(subnet="11.0.0.0/23", name="Root")
         subnet_child = self._create_subnet(


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #104 .


## Description of Changes

Please describe these changes.

This PR adds an **Export Subnets** action to the Subnet admin page, allowing administrators to export **all subnets** in CSV format.

The exported CSV uses the **same structure as the existing import template**, ensuring consistency between import and export workflows.

 Ensured  export order by sorting subnets by creation time.
