### PR TITLE
[deps] Removed explicit django-reversion dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 openwisp-users @ https://github.com/openwisp/openwisp-users/archive/refs/heads/1.3.tar.gz
 openwisp-utils[rest] @ https://github.com/openwisp/openwisp-utils/archive/refs/heads/1.3.tar.gz
-django-reversion~=6.0.0
 openpyxl~=3.1.5


### PR DESCRIPTION
This dependency is already defined in openwisp-users, which this module depends on, therefore the definition here is redundant and can be removed.

Closes #205.