### PR TITLE
[chores:fix] Add ApiKey proxy model and permissions to sample users

### DIFF
--- a/tests/openwisp2/sample_users/migrations/0002_default_groups_and_permissions.py
+++ b/tests/openwisp2/sample_users/migrations/0002_default_groups_and_permissions.py
@@ -3,6 +3,7 @@
 import swapper
 from django.db import migrations
 from openwisp_users.migrations import (
+    add_api_key_permissions_to_admins,
     allow_admins_change_organization,
     create_default_groups,
     set_default_organization_uuid,
@@ -29,5 +30,8 @@ class Migration(migrations.Migration):
         ),
         migrations.RunPython(
             allow_admins_change_organization, reverse_code=migrations.RunPython.noop
+        ),
+        migrations.RunPython(
+            add_api_key_permissions_to_admins, reverse_code=migrations.RunPython.noop
         ),
     ]

--- a/tests/openwisp2/sample_users/migrations/0003_user_expiration_date_user_user_active_expiry_idx.py
+++ b/tests/openwisp2/sample_users/migrations/0003_user_expiration_date_user_user_active_expiry_idx.py
@@ -7,6 +7,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("auth", "0012_alter_user_first_name_max_length"),
+        ("authtoken", "0001_initial"),
         ("sample_users", "0002_default_groups_and_permissions"),
     ]
 

--- a/tests/openwisp2/sample_users/migrations/0003_user_expiration_date_user_user_active_expiry_idx.py
+++ b/tests/openwisp2/sample_users/migrations/0003_user_expiration_date_user_user_active_expiry_idx.py
@@ -21,6 +21,18 @@ class Migration(migrations.Migration):
                 verbose_name="expiration date",
             ),
         ),
+        migrations.CreateModel(
+            name="ApiKey",
+            fields=[],
+            options={
+                "verbose_name": "API key",
+                "verbose_name_plural": "API keys",
+                "proxy": True,
+                "indexes": [],
+                "constraints": [],
+            },
+            bases=("authtoken.token",),
+        ),
         migrations.AddIndex(
             model_name="user",
             index=models.Index(

--- a/tests/openwisp2/sample_users/models.py
+++ b/tests/openwisp2/sample_users/models.py
@@ -1,8 +1,9 @@
 from django.contrib.auth.models import Group as AbstractGroup
 from django.core.validators import RegexValidator
 from django.db import models
-from openwisp_users.base.models import (
+from openwisp_users.base.models import (  # noqa: F401
     AbstractUser,
+    ApiKey,
     BaseGroup,
     BaseOrganization,
     BaseOrganizationOwner,

--- a/tests/openwisp2/sample_users/models.py
+++ b/tests/openwisp2/sample_users/models.py
@@ -1,9 +1,8 @@
 from django.contrib.auth.models import Group as AbstractGroup
 from django.core.validators import RegexValidator
 from django.db import models
-from openwisp_users.base.models import (  # noqa: F401
+from openwisp_users.base.models import (
     AbstractUser,
-    ApiKey,
     BaseGroup,
     BaseOrganization,
     BaseOrganizationOwner,
@@ -48,3 +47,6 @@ class OrganizationInvitation(AbstractOrganizationInvitation):
 
 class Group(BaseGroup, AbstractGroup):
     pass
+
+
+from openwisp_users.base.models import ApiKey  # noqa


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

No existing issue. Replicates openwisp/openwisp-controller@9ca18cc52fd8e68825c509a22054407e10d5f1ee for the IPAM sample app.

## Description of Changes

Adds the `ApiKey` proxy model to the sample users test app migrations and model registration.

Grants API key permissions to sample users admin groups during default group setup.

Adds the `authtoken` migration dependency required by the `ApiKey` proxy model.

## Screenshot

Not applicable. This is a test migration change.