### PR TITLE
[feature] Enforce read-only policy for disabled organizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           pip install -U pip wheel setuptools
           pip install -U -r requirements-test.txt
           pip install -U -e .
+          pip install --upgrade --force-reinstall --no-deps --no-cache-dir https://github.com/openwisp/openwisp-users/tarball/issues/522-disabled-org
           pip install ${{ matrix.django-version }}
           sudo npm install -g prettier
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,16 @@ jobs:
 
       - name: Tests
         if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
+        run: ./runtests
+        env:
+          SELENIUM_HEADLESS: 1
+          GECKO_LOG: 1
+
+      - name: Show gecko web driver log on failures
+        if: ${{ failure() }}
         run: |
-          coverage run ./runtests.py --parallel
-          SAMPLE_APP=1 coverage run ./runtests.py --parallel
-          coverage combine
-          coverage xml
+          [ -f geckodriver.log ] && cat geckodriver.log \
+            || echo "there is no gecko web driver log to show"
 
       - name: Upload Coverage
         if: ${{ success() }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ If instructions conflict, repository config and CI workflows win first, official
 
 - Watch for cross-tenant data leaks, permission bypasses, invalid subnet/IP calculations, unsafe file paths, and secrets.
 - Preserve validation around subnet ranges, IP allocation, overlap checks, and organization ownership.
+- Objects belonging to a disabled organization must be readable and deletable; creation and updates must be blocked across all relevant write paths. This applies to objects with either a direct or chained/nested relationship to the organization. No other operations should be permitted, except for ordinary cleanup operations.
 
 ## Troubleshooting
 

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -59,12 +59,12 @@ Launch development server:
 
 You can access the admin interface at ``http://127.0.0.1:8000/admin/``.
 
-Run tests with:
+Run tests with (make sure you have the :ref:`selenium dependencies
+<selenium_dependencies>` installed locally first):
 
 .. code-block:: shell
 
-    # --parallel and --keepdb are optional but help to speed up the operation
-    ./runtests.py --parallel --keepdb
+    ./runtests
 
 Alternative Sources
 -------------------

--- a/docs/user/import-export-subnets.rst
+++ b/docs/user/import-export-subnets.rst
@@ -43,7 +43,8 @@ created while importing data.
 .. important::
 
     Data can only be imported into active organizations. Imports targeting
-    a disabled organization are rejected.
+    a disabled organization are rejected. A blank organization slug
+    remains supported for shared subnets.
 
 From Management Command
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user/import-export-subnets.rst
+++ b/docs/user/import-export-subnets.rst
@@ -40,6 +40,11 @@ importing data for ip addresses, the system checks if the subnet specified
 in the import file exists or not. If the subnet does not exists it will be
 created while importing data.
 
+.. important::
+
+    Data can only be imported into active organizations. Imports targeting
+    a disabled organization are rejected.
+
 From Management Command
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -114,6 +114,11 @@ Param       Description
 description Optional description for the IP address
 =========== =======================================
 
+.. important::
+
+    If the subnet belongs to a disabled organization, this request is
+    rejected with ``403 Forbidden`` response.
+
 Response
 ++++++++
 
@@ -157,6 +162,11 @@ subnet      Subnet UUID
 description Optional description for the IP address
 =========== =======================================
 
+.. important::
+
+    If the subnet belongs to a disabled organization, this request is
+    rejected with ``403 Forbidden`` response.
+
 Subnet List/Create
 ~~~~~~~~~~~~~~~~~~
 
@@ -187,6 +197,11 @@ subnet        Subnet value in CIDR format
 master_subnet Master Subnet UUID
 description   Optional description for the IP address
 ============= =======================================
+
+.. important::
+
+    Creating a ``Subnet`` in a disabled organization is rejected with
+    ``400 Bad Request`` response.
 
 Subnet Detail
 ~~~~~~~~~~~~~
@@ -228,6 +243,12 @@ master_subnet Master Subnet UUID
 description   Optional description for the IP address
 ============= =======================================
 
+.. important::
+
+    ``Subnet`` belonging to a disabled organization can be viewed or
+    deleted, but updating them is rejected with ``403 Forbidden``, even
+    for superusers.
+
 IP Address Detail
 ~~~~~~~~~~~~~~~~~
 
@@ -268,6 +289,12 @@ ip_address  IPv6/IPv4 value
 subnet      Subnet UUID
 description Optional description for the IP address
 =========== =======================================
+
+.. important::
+
+    ``IP Address`` belonging to a disabled organization can be viewed or
+    deleted, but updating them is rejected with ``403 Forbidden``
+    response.
 
 Export Subnet
 ~~~~~~~~~~~~~

--- a/openwisp_ipam/admin.py
+++ b/openwisp_ipam/admin.py
@@ -39,6 +39,7 @@ class SubnetAdmin(
     app_label = "openwisp_ipam"
     change_form_template = "admin/openwisp-ipam/subnet/change_form.html"
     change_list_template = "admin/openwisp-ipam/subnet/change_list.html"
+    multitenant_shared_relations = ["master_subnet"]
     list_display = [
         "name",
         "organization",

--- a/openwisp_ipam/admin.py
+++ b/openwisp_ipam/admin.py
@@ -105,6 +105,10 @@ class SubnetAdmin(
         available = HostsSet(instance).count() - used
         labels = ["Used", "Available"]
         values = [used, available]
+        is_org_active = instance.organization is None or instance.organization.is_active
+        has_ipaddress_add_permission = is_org_active and self.admin_site._registry[
+            IpAddress
+        ].has_add_permission(request)
         extra_context = {
             "labels": labels,
             "values": values,
@@ -114,6 +118,8 @@ class SubnetAdmin(
             "ipaddress_change_url": ipaddress_change_url,
             "subnet_change_url": subnet_change_url,
             "subnet_tree": subnet_tree,
+            "has_ipaddress_add_permission": has_ipaddress_add_permission,
+            "is_organization_active": is_org_active,
         }
         return super().change_view(request, object_id, form_url, extra_context)
 

--- a/openwisp_ipam/api/serializers.py
+++ b/openwisp_ipam/api/serializers.py
@@ -7,7 +7,7 @@ IpAddress = load_model("openwisp_ipam", "IpAddress")
 Subnet = load_model("openwisp_ipam", "Subnet")
 
 
-class IpRequestSerializer(ValidatedModelSerializer):
+class IpRequestSerializer(FilterSerializerByOrgManaged, ValidatedModelSerializer):
     class Meta:
         model = IpAddress
         fields = ("subnet", "description")

--- a/openwisp_ipam/api/views.py
+++ b/openwisp_ipam/api/views.py
@@ -54,9 +54,15 @@ class DisabledOrgParentSubnetPermission(BasePermission):
             view, "allow_disabled_organization_writes", False
         ):
             return True
-        subnet = view.get_parent_queryset().select_related("organization").first()
+        parent_queryset = view.get_parent_queryset()
+        is_superuser = request.user.is_superuser
+        if not is_superuser:
+            parent_queryset = view.get_organization_queryset(parent_queryset)
+        subnet = parent_queryset.select_related("organization").first()
+        # Managers need an organization-scoped parent; shared subnet writes
+        # are restricted to superusers.
         if subnet is None or subnet.organization_id is None:
-            return True
+            return is_superuser
         return subnet.organization.is_active
 
 

--- a/openwisp_ipam/api/views.py
+++ b/openwisp_ipam/api/views.py
@@ -10,6 +10,7 @@ from openwisp_users.api.mixins import (
     FilterByParentManaged,
     ProtectedAPIMixin as BaseProtectedAPIMixin,
 )
+from openwisp_users.api.permissions import DisabledOrgReadOnly
 from openwisp_utils.api.pagination import OpenWispPagination
 from rest_framework import pagination, serializers, status
 from rest_framework.generics import (
@@ -20,6 +21,7 @@ from rest_framework.generics import (
     RetrieveUpdateDestroyAPIView,
     get_object_or_404,
 )
+from rest_framework.permissions import SAFE_METHODS, BasePermission
 from rest_framework.response import Response
 from rest_framework.utils.urls import remove_query_param, replace_query_param
 
@@ -39,10 +41,32 @@ Subnet = swapper.load_model("openwisp_ipam", "Subnet")
 Organization = swapper.load_model("openwisp_users", "Organization")
 
 
+class DisabledOrgParentSubnetPermission(BasePermission):
+    """
+    Blocks writes when the parent ``Subnet`` belongs to a disabled
+    organization.
+    """
+
+    message = DisabledOrgReadOnly.message
+
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS or getattr(
+            view, "allow_disabled_organization_writes", False
+        ):
+            return True
+        subnet = view.get_parent_queryset().select_related("organization").first()
+        if subnet is None or subnet.organization_id is None:
+            return True
+        return subnet.organization.is_active
+
+
 class IpAddressOrgMixin(FilterByParentManaged):
     def get_parent_queryset(self):
         qs = Subnet.objects.filter(pk=self.kwargs["subnet_id"])
         return qs
+
+    def get_permissions(self):
+        return super().get_permissions() + [DisabledOrgParentSubnetPermission()]
 
 
 class ProtectedAPIMixin(BaseProtectedAPIMixin):
@@ -169,7 +193,7 @@ class AvailableIpView(ProtectedAPIMixin, IpAddressOrgMixin, RetrieveAPIView):
         return Response(subnet.get_next_available_ip())
 
 
-class IpAddressListCreateView(IpAddressOrgMixin, ProtectedAPIMixin, ListCreateAPIView):
+class IpAddressListCreateView(ProtectedAPIMixin, IpAddressOrgMixin, ListCreateAPIView):
     queryset = IpAddress.objects.none()
     subnet_model = Subnet
     serializer_class = IpAddressSerializer
@@ -182,7 +206,7 @@ class IpAddressListCreateView(IpAddressOrgMixin, ProtectedAPIMixin, ListCreateAP
 
 
 class SubnetListCreateView(
-    FilterByOrganizationManaged, ProtectedAPIMixin, ListCreateAPIView
+    ProtectedAPIMixin, FilterByOrganizationManaged, ListCreateAPIView
 ):
     serializer_class = SubnetSerializer
     pagination_class = OpenWispPagination
@@ -247,6 +271,8 @@ class ExportSubnetView(ProtectedAPIMixin, IpAddressOrgMixin, CreateAPIView):
     subnet_model = Subnet
     queryset = Subnet.objects.none()
     serializer_class = serializers.Serializer
+    # this view only reads data (CSV export), even though it uses POST
+    allow_disabled_organization_writes = True
 
     def post(self, request, *args, **kwargs):
         response = HttpResponse(content_type="text/csv")

--- a/openwisp_ipam/base/models.py
+++ b/openwisp_ipam/base/models.py
@@ -273,6 +273,11 @@ class AbstractSubnet(ShareableOrgMixin, TimeStampedEditableModel):
                 "Please create this organization or adapt the CSV file being imported "
                 "by pointing the data to another organization."
             )
+        if not instance.is_active:
+            raise CsvImportException(
+                "The import operation failed because the data being imported "
+                f"belongs to a disabled organization: “{org_slug}”. "
+            )
         return instance
 
 

--- a/openwisp_ipam/base/models.py
+++ b/openwisp_ipam/base/models.py
@@ -275,8 +275,10 @@ class AbstractSubnet(ShareableOrgMixin, TimeStampedEditableModel):
             )
         if not instance.is_active:
             raise CsvImportException(
-                "The import operation failed because the data being imported "
-                f"belongs to a disabled organization: “{org_slug}”. "
+                _(
+                    "The import operation failed because the data being imported "
+                    "belongs to a disabled organization: “{org_slug}”. "
+                ).format(org_slug=org_slug)
             )
         return instance
 

--- a/openwisp_ipam/static/openwisp-ipam/css/admin.css
+++ b/openwisp_ipam/static/openwisp-ipam/css/admin.css
@@ -42,6 +42,10 @@ section.subnet-visual {
   border: 1px solid rgba(0, 0, 0, 0.4);
 }
 
+.subnet-visual a.disabled {
+  cursor: not-allowed;
+}
+
 .subnet-visual .page {
   display: inline;
 }

--- a/openwisp_ipam/static/openwisp-ipam/js/subnet.js
+++ b/openwisp_ipam/static/openwisp-ipam/js/subnet.js
@@ -44,6 +44,9 @@ function initHostsInfiniteScroll(
   address_add_url,
   address_change_url,
   ip_uuid,
+  has_add_permission,
+  is_organization_active,
+  disabled_ipaddress_message,
 ) {
   "use strict";
   var renderedPages = 5,
@@ -52,37 +55,45 @@ function initHostsInfiniteScroll(
     nextPageUrl = "/api/v1/ipam/subnet/" + current_subnet + "/hosts/",
     searchQuery = "",
     lastRenderedPage = 0; //1 based indexing (0 -> no page rendered)
+  function addressLink(address, id, href, class_name, title) {
+    return (
+      '<a id="addr_' +
+      id +
+      '"' +
+      (class_name ? ' class="' + class_name + '"' : "") +
+      (title ? ' title="' + title + '"' : "") +
+      (href ? ' href="' + href + '" onclick="return showAddAnotherPopup(this);"' : "") +
+      ">" +
+      address +
+      "</a>"
+    );
+  }
   function addressListItem(addr) {
     var id = normalizeIP(addr.address);
+    var href = null;
+    var class_name = "";
+    var title = "";
     if (addr.used) {
       var uuid = ip_uuid[addr.address];
-      //note 1234 was passed as a dummy to be later on replaced in the script
-      return (
-        '<a class = "used" href=\"' +
+      href =
         address_change_url.replace("1234", uuid) +
         "?_to_field=id&amp;_popup=1&amp;ip_address=" +
         addr.address +
         "&amp;subnet=" +
-        current_subnet +
-        '"onclick="return showAddAnotherPopup(this);">' +
+        current_subnet;
+      class_name = "used";
+    } else if (has_add_permission) {
+      href =
+        address_add_url +
+        "?_to_field=id&amp;_popup=1&amp;ip_address=" +
         addr.address +
-        "</a>"
-      );
+        "&amp;subnet=" +
+        current_subnet;
+    } else if (!is_organization_active) {
+      class_name = "disabled";
+      title = disabled_ipaddress_message;
     }
-    return (
-      '<a href=\"' +
-      address_add_url +
-      "?_to_field=id&amp;_popup=1&amp;ip_address=" +
-      addr.address +
-      "&amp;subnet=" +
-      current_subnet +
-      '"onclick="return showAddAnotherPopup(this);" ' +
-      'id="addr_' +
-      id +
-      '">' +
-      addr.address +
-      "</a>"
-    );
+    return addressLink(addr.address, id, href, class_name, title);
   }
   function pageContainer(page) {
     var div = $('<div class="page"></div>');

--- a/openwisp_ipam/templates/admin/openwisp-ipam/subnet/change_form.html
+++ b/openwisp_ipam/templates/admin/openwisp-ipam/subnet/change_form.html
@@ -45,7 +45,7 @@
 {% block admin_change_form_document_ready %}
 {{ block.super }}
 {% if original and not is_popup %}
-{% translate "Cannot be create IP Address for a disabled organization." as disabled_ipaddress_message %}
+{% translate "Cannot create IP Address for a disabled organization." as disabled_ipaddress_message %}
 <script type="text/javascript">
   var current_subnet = '{{ original.pk }}';
   var ipAddUrl = '{% url ipaddress_add_url %}'

--- a/openwisp_ipam/templates/admin/openwisp-ipam/subnet/change_form.html
+++ b/openwisp_ipam/templates/admin/openwisp-ipam/subnet/change_form.html
@@ -45,12 +45,16 @@
 {% block admin_change_form_document_ready %}
 {{ block.super }}
 {% if original and not is_popup %}
+{% translate "Cannot be create IP Address for a disabled organization." as disabled_ipaddress_message %}
 <script type="text/javascript">
   var current_subnet = '{{ original.pk }}';
   var ipAddUrl = '{% url ipaddress_add_url %}'
   var ipChangeUrl = '{% url ipaddress_change_url "1234" %}'
+  var hasIpaddressAddPermission = {{ has_ipaddress_add_permission|yesno:"true,false" }};
+  var isOrganizationActive = {{ is_organization_active|yesno:"true,false" }};
+  var disabledIpaddressMessage = "{{ disabled_ipaddress_message|escapejs }}";
   django.jQuery(document).ready(function () {
-    initHostsInfiniteScroll(django.jQuery, current_subnet, ipAddUrl, ipChangeUrl, {{ ip_uuid| safe}})
+    initHostsInfiniteScroll(django.jQuery, current_subnet, ipAddUrl, ipChangeUrl, {{ ip_uuid| safe}}, hasIpaddressAddPermission, isOrganizationActive, disabledIpaddressMessage)
   });
   // Nested Subnet Tree
   subnet_tree = [];
@@ -112,3 +116,4 @@
 </script>
 {% endif %}
 {% endblock %}
+

--- a/openwisp_ipam/tests/__init__.py
+++ b/openwisp_ipam/tests/__init__.py
@@ -45,6 +45,14 @@ class CreateModelsMixin(TestOrganizationMixin):
         instance.save()
         return instance
 
+    def _create_disabled_org_subnet(self, organization=None, **kwargs):
+        if organization is None:
+            organization = self._create_org(name="disabled-org", slug="disabled-org")
+        subnet = self._create_subnet(organization=organization, **kwargs)
+        organization.is_active = False
+        organization.save(update_fields=["is_active"])
+        return subnet
+
 
 class PostDataMixin(object):
     def _post_data(self, **kwargs):

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -476,7 +476,13 @@ class TestAdmin(TestDisabledOrgAdminMixin, CreateModelsMixin, PostDataMixin, Tes
             "description": "",
             "organization": str(org.pk),
         }
-        self._test_disabled_org_admin_crud(subnet, change_data)
+        create_data = {
+            "name": "new-subnet",
+            "subnet": "10.70.1.0/24",
+            "description": "",
+            "organization": str(org.pk),
+        }
+        self._test_disabled_org_admin_crud(subnet, change_data, create_data=create_data)
 
     def test_ipaddress_disabled_org_admin_crud(self):
         org = self._create_org(name="disabled-org", slug="disabled-org")
@@ -489,8 +495,17 @@ class TestAdmin(TestDisabledOrgAdminMixin, CreateModelsMixin, PostDataMixin, Tes
             "subnet": str(subnet.pk),
             "description": "changed",
         }
+        create_data = {
+            "ip_address": "10.71.0.6",
+            "subnet": str(subnet.pk),
+            "description": "",
+        }
         self._test_disabled_org_admin_crud(
-            ip_address, change_data, organization=org, unchanged_field="description"
+            ip_address,
+            change_data,
+            organization=org,
+            unchanged_field="description",
+            create_data=create_data,
         )
 
     def test_subnet_admin_add_form_excludes_disabled_org(self):

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -2,7 +2,7 @@ import json
 
 from django.contrib import admin as django_admin
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
@@ -351,6 +351,30 @@ class TestAdmin(TestDisabledOrgAdminMixin, CreateModelsMixin, PostDataMixin, Tes
         self.assertContains(response, "11.0.0.0/24 (Child#1)")
         self.assertContains(response, "11.0.1.0/24 (Child#2)")
         self.assertContains(response, "11.0.0.0/25 (Grantchild#1)")
+
+    def test_subnet_change_view_ipaddress_add_permission_flag(self):
+        subnet = self._create_subnet(subnet="10.0.0.0/24", description="Sample Subnet")
+        url = reverse(f"admin:{self.app_label}_subnet_change", args=[subnet.id])
+        response = self.client.get(url)
+        self.assertContains(response, "hasIpaddressAddPermission = true;")
+        org = subnet.organization
+        staff_user = self._create_user(
+            username="staff", email="staff@staff.com", is_staff=True
+        )
+        staff_user.user_permissions.add(
+            *Permission.objects.filter(codename__in=["view_subnet", "view_ipaddress"])
+        )
+        self._create_org_user(organization=org, user=staff_user, is_admin=True)
+        self.client.logout()
+        self.client.login(username="staff", password="tester")
+        response = self.client.get(url)
+        self.assertContains(response, "hasIpaddressAddPermission = false;")
+
+    def test_subnet_change_view_disabled_org_excludes_ipaddress_add_permission(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.72.0.0/24")
+        url = reverse(f"admin:{self.app_label}_subnet_change", args=[subnet.id])
+        response = self.client.get(url)
+        self.assertContains(response, "hasIpaddressAddPermission = false;")
 
     def test_subnet_add_rendered(self):
         url = reverse(f"admin:{self.app_label}_subnet_add")

--- a/openwisp_ipam/tests/test_admin.py
+++ b/openwisp_ipam/tests/test_admin.py
@@ -1,10 +1,12 @@
 import json
 
+from django.contrib import admin as django_admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
+from openwisp_users.tests.utils import TestDisabledOrgAdminMixin
 from swapper import load_model
 
 from . import CreateModelsMixin, PostDataMixin
@@ -14,7 +16,7 @@ Subnet = load_model("openwisp_ipam", "Subnet")
 IpAddress = load_model("openwisp_ipam", "IpAddress")
 
 
-class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
+class TestAdmin(TestDisabledOrgAdminMixin, CreateModelsMixin, PostDataMixin, TestCase):
     app_label = "openwisp_ipam"
 
     def setUp(self):
@@ -438,3 +440,144 @@ class TestAdmin(CreateModelsMixin, PostDataMixin, TestCase):
                 reverse("admin:ipam_export_subnet", args=[subnet.id]), follow=True
             )
             assert_response(response)
+
+    def test_subnet_disabled_org_admin_crud(self):
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        subnet = self._create_subnet(organization=org, subnet="10.70.0.0/24")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        change_data = {
+            "name": "changed",
+            "subnet": "10.70.0.0/24",
+            "description": "",
+            "organization": str(org.pk),
+        }
+        self._test_disabled_org_admin_crud(subnet, change_data)
+
+    def test_ipaddress_disabled_org_admin_crud(self):
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        subnet = self._create_subnet(organization=org, subnet="10.71.0.0/24")
+        ip_address = self._create_ipaddress(ip_address="10.71.0.5", subnet=subnet)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        change_data = {
+            "ip_address": "10.71.0.5",
+            "subnet": str(subnet.pk),
+            "description": "changed",
+        }
+        self._test_disabled_org_admin_crud(
+            ip_address, change_data, organization=org, unchanged_field="description"
+        )
+
+    def test_subnet_admin_add_form_excludes_disabled_org(self):
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        url = reverse(f"admin:{self.app_label}_subnet_add")
+        self._test_disabled_org_admin_org_field_excludes_disabled(url, org)
+        self.client.login(username="admin", password="tester")
+        post_data = {
+            "name": "should-not-be-created",
+            "subnet": "10.72.0.0/24",
+            "description": "",
+            "organization": str(org.pk),
+        }
+        response = self.client.post(url, post_data, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Subnet.objects.filter(subnet="10.72.0.0/24").count(), 0)
+
+    def test_subnet_admin_master_subnet_excludes_disabled_org(self):
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        disabled_subnet = self._create_subnet(organization=org, subnet="10.73.0.0/24")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        request = RequestFactory().get(reverse(f"admin:{self.app_label}_subnet_add"))
+        request.user = User.objects.get(username="admin")
+        model_admin = django_admin.site._registry[Subnet]
+        form_class = model_admin.get_form(request)
+        master_subnet_qs = form_class.base_fields["master_subnet"].queryset
+        self.assertNotIn(
+            disabled_subnet.pk, master_subnet_qs.values_list("pk", flat=True)
+        )
+
+    def test_ipaddress_admin_add_form_excludes_disabled_org_subnet(self):
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        disabled_subnet = self._create_subnet(organization=org, subnet="10.74.0.0/24")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        request = RequestFactory().get(reverse(f"admin:{self.app_label}_ipaddress_add"))
+        request.user = User.objects.get(username="admin")
+        model_admin = django_admin.site._registry[IpAddress]
+        form_class = model_admin.get_form(request)
+        subnet_qs = form_class.base_fields["subnet"].queryset
+        self.assertNotIn(disabled_subnet.pk, subnet_qs.values_list("pk", flat=True))
+        post_data = {
+            "ip_address": "10.74.0.5",
+            "subnet": str(disabled_subnet.pk),
+            "description": "",
+        }
+        response = self.client.post(
+            reverse(f"admin:{self.app_label}_ipaddress_add"), post_data, follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(IpAddress.objects.filter(ip_address="10.74.0.5").count(), 0)
+
+    def test_admin_export_view_disabled_org(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.75.0.0/24")
+        url = reverse("admin:ipam_export_subnet", args=[subnet.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+
+    def test_admin_import_view_disabled_org(self):
+        org = self._create_org(name="disabled-import-org", slug="disabled-import-org")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        csv_data = """Disabled Import,
+        10.76.1.0/24,
+        disabled-import-org,
+        ,
+        ip address,description
+        10.76.1.1,Disabled"""
+        csvfile = SimpleUploadedFile("data.csv", bytes(csv_data, "utf-8"))
+        response = self.client.post(
+            reverse("admin:ipam_import_subnet"), {"csvfile": csvfile}, follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "The import operation failed because the data being imported "
+            "belongs to a disabled organization: “disabled-import-org”.",
+        )
+        self.assertEqual(Subnet.objects.filter(subnet="10.76.1.0/24").count(), 0)
+
+    def test_subnet_admin_delete_selected_disabled_org(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.77.0.0/24")
+        url = reverse(f"admin:{self.app_label}_subnet_changelist")
+        response = self.client.post(
+            url,
+            {
+                "action": "delete_selected",
+                "_selected_action": [str(subnet.pk)],
+                "post": "yes",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Subnet.objects.filter(pk=subnet.pk).exists(), False)
+
+    def test_ipaddress_admin_delete_selected_disabled_org(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.78.0.0/24")
+        ip_address = self._create_ipaddress(ip_address="10.78.0.5", subnet=subnet)
+        url = reverse(f"admin:{self.app_label}_ipaddress_changelist")
+        response = self.client.post(
+            url,
+            {
+                "action": "delete_selected",
+                "_selected_action": [str(ip_address.pk)],
+                "post": "yes",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(IpAddress.objects.filter(pk=ip_address.pk).exists(), False)

--- a/openwisp_ipam/tests/test_api.py
+++ b/openwisp_ipam/tests/test_api.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
+from openwisp_users.tests.test_api import AuthenticationMixin, TestDisabledOrgApiMixin
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 from swapper import load_model
 
@@ -14,7 +15,14 @@ Subnet = load_model("openwisp_ipam", "Subnet")
 IpAddress = load_model("openwisp_ipam", "IpAddress")
 
 
-class TestApi(TestMultitenantAdminMixin, CreateModelsMixin, PostDataMixin, TestCase):
+class TestApi(
+    TestMultitenantAdminMixin,
+    TestDisabledOrgApiMixin,
+    AuthenticationMixin,
+    CreateModelsMixin,
+    PostDataMixin,
+    TestCase,
+):
     def setUp(self):
         super().setUp()
         self._login()
@@ -351,3 +359,128 @@ class TestApi(TestMultitenantAdminMixin, CreateModelsMixin, PostDataMixin, TestC
         host_address_32 = response.data["results"][0]["address"]
         self.assertEqual(host_address_128, "2001:db00::")
         self.assertEqual(host_address_32, "192.168.0.0")
+
+    def test_subnet_disabled_org_api_crud(self):
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        subnet = self._create_subnet(organization=org, subnet="10.50.0.0/24")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_api_crud(
+            subnet,
+            detail_url=reverse("ipam:subnet", args=[subnet.pk]),
+            list_url=reverse("ipam:subnet_list_create"),
+            create_payload={
+                "name": "new-subnet",
+                "subnet": "10.51.0.0/24",
+                "organization": str(org.pk),
+            },
+            update_payload={"name": "changed"},
+        )
+
+    def test_ipaddress_disabled_org_api_crud(self):
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        subnet = self._create_subnet(organization=org, subnet="10.52.0.0/24")
+        ip_address = self._create_ipaddress(ip_address="10.52.0.5", subnet=subnet)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_api_crud(
+            ip_address,
+            detail_url=reverse("ipam:ip_address", args=[ip_address.pk]),
+            list_url=reverse("ipam:list_create_ip_address", args=[subnet.pk]),
+            create_payload={"subnet": str(subnet.pk), "ip_address": "10.52.0.6"},
+            update_payload={"description": "changed"},
+            unchanged_field="description",
+            organization=org,
+            # `IpAddress` has no `organization` field of its own, so the
+            # nested create is blocked by `DisabledOrgParentSubnetPermission`
+            # (403), not by the serializer's default 400 create expectation.
+            superuser_expected={"create": {"status": 403}},
+        )
+
+    def test_ipaddress_api_cannot_move_to_disabled_org_subnet(self):
+        active_org = self._get_org()
+        active_subnet = self._create_subnet(
+            organization=active_org, subnet="10.53.0.0/24"
+        )
+        ip_address = self._create_ipaddress(
+            ip_address="10.53.0.5", subnet=active_subnet
+        )
+        disabled_subnet = self._create_disabled_org_subnet(subnet="10.54.0.0/24")
+        response = self.client.patch(
+            reverse("ipam:ip_address", args=(ip_address.id,)),
+            data=json.dumps({"subnet": str(disabled_subnet.id)}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("subnet", response.data)
+        ip_address.refresh_from_db()
+        self.assertEqual(ip_address.subnet_id, active_subnet.id)
+
+    def test_request_ip_disabled_org_api(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.55.0.0/24")
+        response = self.client.post(
+            reverse("ipam:request_ip", args=(subnet.id,)),
+            data=json.dumps({"description": "Testing"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(IpAddress.objects.filter(subnet=subnet).count(), 0)
+
+    def test_create_ip_address_disabled_org_api(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.56.0.0/24")
+        post_data = json.dumps({"subnet": str(subnet.id), "ip_address": "10.56.0.5"})
+        response = self.client.post(
+            reverse("ipam:list_create_ip_address", args=(subnet.id,)),
+            data=post_data,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(IpAddress.objects.filter(subnet=subnet).count(), 0)
+
+    def test_get_next_available_ip_disabled_org_api(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.57.0.0/24")
+        response = self.client.get(
+            reverse("ipam:get_next_available_ip", args=(subnet.id,))
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_subnet_hosts_disabled_org_api(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.58.0.0/24")
+        response = self.client.get(reverse("ipam:hosts", args=(subnet.id,)))
+        self.assertEqual(response.status_code, 200)
+
+    def test_export_subnet_disabled_org_api(self):
+        subnet = self._create_disabled_org_subnet(
+            subnet="10.59.0.0/24", name="Disabled export"
+        )
+        response = self.client.post(reverse("ipam:export-subnet", args=(subnet.id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+
+    def test_import_subnet_disabled_org_api(self):
+        org = self._create_org(name="disabled-import-org", slug="disabled-import-org")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        csv_data = """Disabled Import,
+        10.60.1.0/24,
+        disabled-import-org,
+        ,
+        ip address,description
+        10.60.1.1,Disabled"""
+        csvfile = SimpleUploadedFile("data.csv", bytes(csv_data, "utf-8"))
+        response = self.client.post(reverse("ipam:import-subnet"), {"csvfile": csvfile})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("disabled organization", response.data["error"])
+        self.assertEqual(Subnet.objects.filter(subnet="10.60.1.0/24").count(), 0)
+
+    def test_import_subnet_shared_org_api(self):
+        csv_data = """Shared subnet,
+        10.61.1.0/24,
+        ,
+        ,
+        ip address,description
+        10.61.1.1,Shared"""
+        csvfile = SimpleUploadedFile("data.csv", bytes(csv_data, "utf-8"))
+        response = self.client.post(reverse("ipam:import-subnet"), {"csvfile": csvfile})
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(Subnet.objects.get(subnet="10.61.1.0/24").organization)

--- a/openwisp_ipam/tests/test_commands.py
+++ b/openwisp_ipam/tests/test_commands.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import tempfile
 from io import StringIO
 
 from django.core.management import CommandError, call_command
@@ -46,6 +47,33 @@ class TestCommands(CreateModelsMixin, FileMixin, TestCase):
             call_command("import_subnet", file="invalid.pdf")
         with self.assertRaises(CommandError):
             call_command("import_subnet", file="invalid_path.csv")
+
+    def test_import_subnet_command_disabled_org(self):
+        org = self._create_org(name="disabled-import-org", slug="disabled-import-org")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        csv_data = (
+            "Disabled Import,\n"
+            "10.80.1.0/24,\n"
+            "disabled-import-org,\n"
+            ",\n"
+            "ip address,description\n"
+            "10.80.1.1,Disabled\n"
+        )
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False
+        ) as csvfile:
+            csvfile.write(csv_data)
+            csvfile_path = csvfile.name
+        self.addCleanup(os.remove, csvfile_path)
+        with self.assertRaises(CommandError) as ctx:
+            call_command("import_subnet", file=csvfile_path)
+        self.assertEqual(
+            str(ctx.exception),
+            "The import operation failed because the data being imported "
+            "belongs to a disabled organization: “disabled-import-org”. ",
+        )
+        self.assertEqual(Subnet.objects.filter(subnet="10.80.1.0/24").count(), 0)
 
     @classmethod
     def tearDownClass(cls):

--- a/openwisp_ipam/tests/test_multitenant.py
+++ b/openwisp_ipam/tests/test_multitenant.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -311,6 +313,43 @@ class TestMultitenantApi(
             self._login(username="user_b", password="tester")
             response = self.client.post(**post_data)
             self.assertEqual(response.status_code, 404)
+
+    def test_nested_ipaddress_writes_reject_other_organizations(self):
+        """Prevent nested writes from bypassing organization isolation."""
+        org_b = self._get_org(org_name="org_b")
+        org_c = self._create_org(name="org_c", slug="org_c")
+        active_subnet = self._create_subnet(subnet="10.1.0.0/24", organization=org_b)
+        disabled_subnet = self._create_subnet(subnet="10.2.0.0/24", organization=org_c)
+        org_c.is_active = False
+        org_c.save(update_fields=["is_active"])
+        self._login(username="user_a", password="tester")
+
+        for subnet, label in (
+            (active_subnet, "active subnet"),
+            (disabled_subnet, "disabled subnet"),
+        ):
+            with self.subTest(f"request IP for other organization's {label}"):
+                response = self.client.post(
+                    reverse("ipam:request_ip", args=(subnet.id,)),
+                    data=json.dumps({"description": "Testing"}),
+                    content_type="application/json",
+                )
+                self.assertEqual(response.status_code, 404)
+
+            with self.subTest(f"create IP for other organization's {label}"):
+                response = self.client.post(
+                    reverse("ipam:list_create_ip_address", args=(subnet.id,)),
+                    data=json.dumps(
+                        {
+                            "ip_address": f"{subnet.subnet.network_address + 5}",
+                            "subnet": str(subnet.id),
+                        }
+                    ),
+                    content_type="application/json",
+                )
+                self.assertEqual(response.status_code, 404)
+
+        self.assertEqual(IpAddress.objects.count(), 0)
 
     def test_import_subnet(self):
         csv_data = """Monachers - Matera,

--- a/openwisp_ipam/tests/test_multitenant.py
+++ b/openwisp_ipam/tests/test_multitenant.py
@@ -434,12 +434,20 @@ class TestMultitenantApi(
         url = f'{reverse("ipam:subnet_list_create")}?format=api'
 
         with self.subTest(
-            "Test `Organization` and `Master subnet` field filter for org manager"
+            "Test `Organization` and `Master subnet` field filter for administrator"
         ):
-            self._login(username="user_a", password="tester")
+            self._login(username="administrator", password="tester")
             response = self.client.get(url)
             self.assertContains(response, "org_a</option>")
             self.assertContains(response, "10.0.0.0/24</option>")
+            self.assertNotContains(response, "org_b</option>")
+            self.assertNotContains(response, "10.10.0.0/24</option>")
+
+        with self.subTest("Operators can only view subnets in their organization"):
+            self._login(username="user_a", password="tester")
+            response = self.client.get(url)
+            self.assertNotContains(response, "org_a</option>")
+            self.assertNotContains(response, "10.0.0.0/24</option>")
             self.assertNotContains(response, "org_b</option>")
             self.assertNotContains(response, "10.10.0.0/24</option>")
 

--- a/openwisp_ipam/tests/test_selenium.py
+++ b/openwisp_ipam/tests/test_selenium.py
@@ -1,0 +1,71 @@
+from django.contrib.auth.models import Permission
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test import tag
+from django.urls import reverse
+from openwisp_utils.tests.selenium import SeleniumTestMixin
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+
+from . import CreateModelsMixin
+
+
+@tag("selenium_tests")
+class TestSubnetChangeViewSelenium(
+    SeleniumTestMixin, CreateModelsMixin, StaticLiveServerTestCase
+):
+    app_label = "openwisp_ipam"
+
+    def test_available_address_popup_respects_add_permission(self):
+        subnet = self._create_subnet(subnet="10.0.0.0/29", description="Sample Subnet")
+        address_id = "addr_10001"  # 10.0.0.1 with dots stripped
+        staff_user = self._create_user(
+            username="staff", password="tester", email="staff@staff.com", is_staff=True
+        )
+        staff_user.user_permissions.add(
+            *Permission.objects.filter(codename__in=["view_subnet", "view_ipaddress"])
+        )
+        self._create_org_user(
+            organization=subnet.organization, user=staff_user, is_admin=True
+        )
+        url = reverse(f"admin:{self.app_label}_subnet_change", args=[subnet.id])
+
+        with self.subTest("without add permission"):
+            self.login(username="staff", password="tester")
+            self.open(url)
+            address_element = self.find_element(By.ID, address_id)
+            self.assertEqual(address_element.tag_name, "a")
+            address_element.click()
+            self.assertEqual(len(self.web_driver.window_handles), 1)
+        self.logout()
+
+        with self.subTest("with add permission"):
+            self.login()
+            self.open(url)
+            address_element = self.find_element(By.ID, address_id)
+            self.assertEqual(address_element.tag_name, "a")
+            address_element.click()
+            WebDriverWait(self.web_driver, 5).until(
+                lambda driver: len(driver.window_handles) == 2
+            )
+            self.web_driver.switch_to.window(self.web_driver.window_handles[-1])
+            self.assertIn(
+                reverse(f"admin:{self.app_label}_ipaddress_add"),
+                self.web_driver.current_url,
+            )
+
+    def test_available_address_popup_hidden_for_disabled_org(self):
+        subnet = self._create_disabled_org_subnet(subnet="10.72.0.0/29")
+        address_id = "addr_1072001"  # 10.72.0.1 with dots stripped
+        # Even a superuser must not be able to open a popup when the subnet's
+        # organization is disabled.
+        self.login()
+        self.open(reverse(f"admin:{self.app_label}_subnet_change", args=[subnet.id]))
+        address_element = self.find_element(By.ID, address_id)
+        self.assertEqual(address_element.tag_name, "a")
+        self.assertEqual(
+            address_element.get_attribute("title"),
+            "IP addresses cannot be created for a disabled organization.",
+        )
+        self.assertEqual(address_element.get_attribute("class"), "disabled")
+        address_element.click()
+        self.assertEqual(len(self.web_driver.window_handles), 1)

--- a/openwisp_ipam/tests/test_selenium.py
+++ b/openwisp_ipam/tests/test_selenium.py
@@ -17,7 +17,6 @@ class TestSubnetChangeViewSelenium(
 
     def test_available_address_popup_respects_add_permission(self):
         subnet = self._create_subnet(subnet="10.0.0.0/29", description="Sample Subnet")
-        address_id = "addr_10001"  # 10.0.0.1 with dots stripped
         staff_user = self._create_user(
             username="staff", password="tester", email="staff@staff.com", is_staff=True
         )
@@ -32,8 +31,7 @@ class TestSubnetChangeViewSelenium(
         with self.subTest("without add permission"):
             self.login(username="staff", password="tester")
             self.open(url)
-            address_element = self.find_element(By.ID, address_id)
-            self.assertEqual(address_element.tag_name, "a")
+            address_element = self.find_element(By.CSS_SELECTOR, "a#addr_10001")
             address_element.click()
             self.assertEqual(len(self.web_driver.window_handles), 1)
         self.logout()
@@ -41,8 +39,7 @@ class TestSubnetChangeViewSelenium(
         with self.subTest("with add permission"):
             self.login()
             self.open(url)
-            address_element = self.find_element(By.ID, address_id)
-            self.assertEqual(address_element.tag_name, "a")
+            address_element = self.find_element(By.CSS_SELECTOR, "a#addr_10001")
             address_element.click()
             WebDriverWait(self.web_driver, 5).until(
                 lambda driver: len(driver.window_handles) == 2
@@ -54,17 +51,18 @@ class TestSubnetChangeViewSelenium(
             )
 
     def test_available_address_popup_hidden_for_disabled_org(self):
-        subnet = self._create_disabled_org_subnet(subnet="10.72.0.0/29")
-        address_id = "addr_1072001"  # 10.72.0.1 with dots stripped
+        organization = self._create_org(name="disabled org", slug="disabled-org")
+        subnet = self._create_disabled_org_subnet(
+            organization=organization, subnet="10.72.0.0/29"
+        )
         # Even a superuser must not be able to open a popup when the subnet's
         # organization is disabled.
         self.login()
         self.open(reverse(f"admin:{self.app_label}_subnet_change", args=[subnet.id]))
-        address_element = self.find_element(By.ID, address_id)
-        self.assertEqual(address_element.tag_name, "a")
+        address_element = self.find_element(By.CSS_SELECTOR, "a#addr_107201")
         self.assertEqual(
             address_element.get_attribute("title"),
-            "IP addresses cannot be created for a disabled organization.",
+            "Cannot create IP Address for a disabled organization.",
         )
         self.assertEqual(address_element.get_attribute("class"), "disabled")
         address_element.click()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-openwisp-utils[qa] @ https://github.com/openwisp/openwisp-utils/archive/refs/heads/1.3.tar.gz
+openwisp-utils[qa,selenium] @ https://github.com/openwisp/openwisp-utils/archive/refs/heads/1.3.tar.gz
 # sample_users tests
 freezegun>=1.5.5,<1.6.0

--- a/runtests
+++ b/runtests
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+coverage erase
+
+echo "Starting standard tests"
+coverage run ./runtests.py --parallel --exclude-tag=selenium_tests \
+  || coverage run ./runtests.py --exclude-tag=selenium_tests
+
+echo "Starting selenium browser tests"
+coverage run ./runtests.py --tag=selenium_tests --no-input --exclude-pytest
+
+echo "Starting tests for extensibility"
+SAMPLE_APP=1 coverage run ./runtests.py \
+  --parallel --exclude-tag=selenium_tests \
+  || SAMPLE_APP=1 coverage run ./runtests.py --exclude-tag=selenium_tests
+
+coverage combine
+coverage xml

--- a/runtests
+++ b/runtests
@@ -8,7 +8,7 @@ coverage run ./runtests.py --parallel --exclude-tag=selenium_tests \
   || coverage run ./runtests.py --exclude-tag=selenium_tests
 
 echo "Starting selenium browser tests"
-coverage run ./runtests.py --tag=selenium_tests --no-input --exclude-pytest
+coverage run ./runtests.py --tag=selenium_tests --no-input
 
 echo "Starting tests for extensibility"
 SAMPLE_APP=1 coverage run ./runtests.py \


### PR DESCRIPTION

## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Description of Changes

Objects belonging to disabled organizations can only be read or deleted. Creation and updates are rejected across the REST API, Django admin, and CSV imports.

Added tests covering the disabled-organization CRUD behavior across all supported interfaces.

## Blockers 

- [ ] https://github.com/openwisp/openwisp-users/pull/542

## Screenshot

**Subnet admin is rendered as readonly**

<img width="1532" height="1830" alt="image" src="https://github.com/user-attachments/assets/8fe45782-537b-473f-9275-24f8c2dc59ab" />

**IP address from a disabled organization is readonly**

<img width="1365" height="683" alt="image" src="https://github.com/user-attachments/assets/4d8567d4-9f8d-4670-87a3-5531eeabcf54" />


