### PR TITLE
[chores] Used theme colors from openwisp-utils variables #200

### DIFF
--- a/openwisp_ipam/static/openwisp-ipam/css/admin.css
+++ b/openwisp_ipam/static/openwisp-ipam/css/admin.css
@@ -17,9 +17,9 @@ section.subnet-visual {
   padding: 5px 0;
   margin: 0 10px 10px 0px;
   border-radius: 0;
-  color: #fff;
-  background: rgba(20, 102, 26, 0.9);
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  color: var(--ow-color-white);
+  background: var(--ow-color-success);
+  border: 1px solid var(--ow-overlay-25);
   font-weight: normal;
   text-decoration: none !important;
 }
@@ -30,16 +30,16 @@ section.subnet-visual {
   padding: 8px 5px;
 }
 .subnet-visual a:hover {
-  background: rgba(20, 102, 26, 1);
-  border: 1px solid rgba(0, 0, 0, 0.4);
+  background: color-mix(in srgb, var(--ow-color-success), black 15%);
+  border: 1px solid var(--ow-overlay-40);
 }
 .subnet-visual a.used {
-  background: rgba(149, 10, 10, 0.9);
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: var(--ow-color-danger);
+  border: 1px solid var(--ow-overlay-25);
 }
 .subnet-visual a.used:hover {
-  background: rgba(149, 10, 10, 1);
-  border: 1px solid rgba(0, 0, 0, 0.4);
+  background: color-mix(in srgb, var(--ow-color-danger), black 15%);
+  border: 1px solid var(--ow-overlay-40);
 }
 
 .subnet-visual .page {

--- a/openwisp_ipam/static/openwisp-ipam/css/admin.css
+++ b/openwisp_ipam/static/openwisp-ipam/css/admin.css
@@ -30,7 +30,7 @@ section.subnet-visual {
   padding: 8px 5px;
 }
 .subnet-visual a:hover {
-  background: color-mix(in srgb, var(--ow-color-success), black 15%);
+  background: color-mix(in srgb, var(--ow-color-success), var(--ow-color-black) 15%);
   border: 1px solid var(--ow-overlay-40);
 }
 .subnet-visual a.used {
@@ -38,7 +38,7 @@ section.subnet-visual {
   border: 1px solid var(--ow-overlay-25);
 }
 .subnet-visual a.used:hover {
-  background: color-mix(in srgb, var(--ow-color-danger), black 15%);
+  background: color-mix(in srgb, var(--ow-color-danger), var(--ow-color-black) 15%);
   border: 1px solid var(--ow-overlay-40);
 }
 

--- a/openwisp_ipam/templates/admin/openwisp-ipam/subnet/change_form.html
+++ b/openwisp_ipam/templates/admin/openwisp-ipam/subnet/change_form.html
@@ -81,6 +81,7 @@
     parent_element.appendChild(subnet_list);
   }
   // Ipam Graph / Visual
+  var rootStyle = getComputedStyle(document.documentElement);
   var data = [],
     layout = {},
     vals = {{ values| safe }}
@@ -95,13 +96,13 @@
     textinfo: 'percent',
     marker: {
       colors: [
-        'rgba(149, 10, 10, 1)',
-        'rgba(20, 102, 26, 1)'
+        rootStyle.getPropertyValue('--ow-color-danger').trim(),
+        rootStyle.getPropertyValue('--ow-color-success').trim()
       ]
     },
     textfont: {
       size: 18,
-      color: '#FFF',
+      color: rootStyle.getPropertyValue('--ow-color-white').trim(),
     }
       }
   ];


### PR DESCRIPTION

## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #200.

## Description of Changes

Replaced hardcoded colors in CSS with the theme variables from openwisp-utils#516. Also updated the pie chart in the template, since Plotly needs the resolved values.

## Screenshot
Before:
<img width="1841" height="880" alt="Screenshot (971)" src="https://github.com/user-attachments/assets/9f7abc23-9a2e-4b7d-a998-d3082391e69e" />

After:
<img width="1848" height="899" alt="Screenshot (975)" src="https://github.com/user-attachments/assets/ec952eb6-cb12-4c95-9470-7ae6af1582b7" />

