### PR TITLE
[ci] Removed unsupported Django versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,7 @@ jobs:
           - "3.12"
           - "3.13"
         django-version:
-          - django~=4.2.0
-          - django~=5.1.0
           - django~=5.2.0
-        exclude:
-          # Python 3.13 supported only in Django >=5.1.3
-          - python-version: "3.13"
-            django-version: django~=4.2.0
 
     steps:
       - uses: actions/checkout@v7
@@ -66,6 +60,7 @@ jobs:
           pip install -U -r requirements-test.txt
           pip install -U -e .
           pip install ${{ matrix.django-version }}
+          pip check
           sudo npm install -g prettier
 
       - name: QA checks


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

N/A, no existing issue.

## Description of Changes

Restricts the CI matrix to Django 5.2, which is compatible with the current shared OpenWISP dependency versions. Adds `pip check` after dependency installation so incompatible requirements fail before the parallel test runner can mask their underlying error.

## Screenshot

N/A
