### PR TITLE
[change] Allowed partial override of API views #232

### DIFF
--- a/docs/developer/extending.rst
+++ b/docs/developer/extending.rst
@@ -279,9 +279,13 @@ Substitute ``myipam`` with the name you chose in step 1.
     urlpatterns = [
         # ... other urls in your project ...
         # openwisp-ipam urls
-        # path('', include(get_urls(api_views))) <-- Use only when changing API views (dicussed below)
+        # path('', include(get_urls(api_views))) <-- Use only when changing API views (see below)
         path("", include("openwisp_ipam.urls")),
     ]
+
+The ``api_views`` module only needs to contain the views you want to
+override. Any view which is not found in it will fall back to the default
+implementation, so there is no need to redefine all the views.
 
 For more information about URL configuration in django, please refer to
 the `"URL dispatcher" section in the django documentation

--- a/openwisp_ipam/api/urls.py
+++ b/openwisp_ipam/api/urls.py
@@ -1,42 +1,51 @@
 from django.urls import path
 
+from . import views
 
-def get_api_urls(api_views):
+
+def get_api_urls(api_views=None):
     """
     returns:: all the API urls of the app
     arguments::
-        api_views: location for getting API views
+        api_views: optional module or object providing custom API views,
+                   any view not found in it falls back to the default one
     """
+    if api_views is None:
+        api_views = views
+
+    def get_view(name):
+        """Fall back to the standard view when a custom view is unavailable."""
+        return getattr(api_views, name, getattr(views, name))
 
     return [
-        path("import-subnet/", api_views.import_subnet, name="import-subnet"),
+        path("import-subnet/", get_view("import_subnet"), name="import-subnet"),
         path(
             "subnet/<str:subnet_id>/get-next-available-ip/",
-            api_views.get_next_available_ip,
+            get_view("get_next_available_ip"),
             name="get_next_available_ip",
         ),
         path(
             "subnet/<str:subnet_id>/request-ip/",
-            api_views.request_ip,
+            get_view("request_ip"),
             name="request_ip",
         ),
         path(
             "subnet/<str:subnet_id>/export/",
-            api_views.export_subnet,
+            get_view("export_subnet"),
             name="export-subnet",
         ),
         path(
             "subnet/<str:subnet_id>/ip-address/",
-            api_views.subnet_list_ipaddress,
+            get_view("subnet_list_ipaddress"),
             name="list_create_ip_address",
         ),
-        path("subnet/", api_views.subnet_list_create, name="subnet_list_create"),
-        path("subnet/<str:pk>/", api_views.subnet, name="subnet"),
-        path("subnet/<str:subnet_id>/hosts/", api_views.subnet_hosts, name="hosts"),
+        path("subnet/", get_view("subnet_list_create"), name="subnet_list_create"),
+        path("subnet/<str:pk>/", get_view("subnet"), name="subnet"),
+        path("subnet/<str:subnet_id>/hosts/", get_view("subnet_hosts"), name="hosts"),
         path(
             "subnet/<str:subnet_id>/allocation/",
-            api_views.subnet_allocation,
+            get_view("subnet_allocation"),
             name="subnet_allocation",
         ),
-        path("ip-address/<str:pk>/", api_views.ip_address, name="ip_address"),
+        path("ip-address/<str:pk>/", get_view("ip_address"), name="ip_address"),
     ]

--- a/openwisp_ipam/tests/test_api.py
+++ b/openwisp_ipam/tests/test_api.py
@@ -11,6 +11,7 @@ from swapper import load_model
 
 from openwisp_ipam.api import views
 from openwisp_ipam.api.urls import get_api_urls
+from openwisp_ipam.urls import get_urls
 
 from . import CreateModelsMixin, PostDataMixin
 
@@ -524,11 +525,22 @@ class TestApiUrls(SimpleTestCase):
         callbacks = {
             pattern.name: pattern.callback for pattern in get_api_urls(custom_views)
         }
+        wrapper_default_callbacks = {
+            pattern.name: pattern.callback for pattern in get_urls()[0].url_patterns
+        }
+        wrapper_callbacks = {
+            pattern.name: pattern.callback
+            for pattern in get_urls(custom_views)[0].url_patterns
+        }
         for url_name, view_name in view_names.items():
 
             with self.subTest(url_name=url_name):
-                self.assertIs(default_callbacks[url_name], getattr(views, view_name))
                 expected = (
                     views.subnet_hosts if view_name == "subnet_hosts" else custom_view
                 )
+                self.assertIs(default_callbacks[url_name], getattr(views, view_name))
                 self.assertIs(callbacks[url_name], expected)
+                self.assertIs(
+                    wrapper_default_callbacks[url_name], getattr(views, view_name)
+                )
+                self.assertIs(wrapper_callbacks[url_name], expected)

--- a/openwisp_ipam/tests/test_api.py
+++ b/openwisp_ipam/tests/test_api.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 from openwisp_utils.tests import AssertNumQueriesSubTestMixin
@@ -494,17 +494,41 @@ class TestApi(
         self.assertEqual(host_address_32, "192.168.0.0")
 
 
-class TestApiUrls(TestCase):
-    def test_get_api_urls_without_api_views(self):
-        url_map = {url.name: url.callback for url in get_api_urls()}
-        self.assertEqual(url_map["hosts"], views.subnet_hosts)
-        self.assertEqual(url_map["subnet"], views.subnet)
+class TestApiUrls(SimpleTestCase):
+    def test_get_api_urls_uses_overrides_and_default_fallbacks(self):
+        def custom_view(request):
+            return None
 
-    def test_get_api_urls_with_partial_api_views(self):
-        def custom_subnet_hosts(request, *args, **kwargs):
-            pass
+        view_names = {
+            "import-subnet": "import_subnet",
+            "get_next_available_ip": "get_next_available_ip",
+            "request_ip": "request_ip",
+            "export-subnet": "export_subnet",
+            "list_create_ip_address": "subnet_list_ipaddress",
+            "subnet_list_create": "subnet_list_create",
+            "subnet": "subnet",
+            "hosts": "subnet_hosts",
+            "subnet_allocation": "subnet_allocation",
+            "ip_address": "ip_address",
+        }
+        default_callbacks = {
+            pattern.name: pattern.callback for pattern in get_api_urls()
+        }
+        custom_views = SimpleNamespace(
+            **{
+                view_name: custom_view
+                for view_name in view_names.values()
+                if view_name != "subnet_hosts"
+            }
+        )
+        callbacks = {
+            pattern.name: pattern.callback for pattern in get_api_urls(custom_views)
+        }
+        for url_name, view_name in view_names.items():
 
-        custom_views = SimpleNamespace(subnet_hosts=custom_subnet_hosts)
-        url_map = {url.name: url.callback for url in get_api_urls(custom_views)}
-        self.assertEqual(url_map["hosts"], custom_subnet_hosts)
-        self.assertEqual(url_map["subnet"], views.subnet)
+            with self.subTest(url_name=url_name):
+                self.assertIs(default_callbacks[url_name], getattr(views, view_name))
+                expected = (
+                    views.subnet_hosts if view_name == "subnet_hosts" else custom_view
+                )
+                self.assertIs(callbacks[url_name], expected)

--- a/openwisp_ipam/tests/test_api.py
+++ b/openwisp_ipam/tests/test_api.py
@@ -497,8 +497,6 @@ class TestApi(
 
 class TestApiUrls(SimpleTestCase):
     def test_get_api_urls_uses_overrides_and_default_fallbacks(self):
-        def custom_view(request):
-            return None
 
         view_names = {
             "import-subnet": "import_subnet",
@@ -517,7 +515,7 @@ class TestApiUrls(SimpleTestCase):
         }
         custom_views = SimpleNamespace(
             **{
-                view_name: custom_view
+                view_name: (lambda request, _name=view_name: None)
                 for view_name in view_names.values()
                 if view_name != "subnet_hosts"
             }
@@ -536,7 +534,9 @@ class TestApiUrls(SimpleTestCase):
 
             with self.subTest(url_name=url_name):
                 expected = (
-                    views.subnet_hosts if view_name == "subnet_hosts" else custom_view
+                    views.subnet_hosts
+                    if view_name == "subnet_hosts"
+                    else getattr(custom_views, view_name)
                 )
                 self.assertIs(default_callbacks[url_name], getattr(views, view_name))
                 self.assertIs(callbacks[url_name], expected)

--- a/openwisp_ipam/tests/test_api.py
+++ b/openwisp_ipam/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -7,6 +8,9 @@ from django.urls import reverse
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 from openwisp_utils.tests import AssertNumQueriesSubTestMixin
 from swapper import load_model
+
+from openwisp_ipam.api import views
+from openwisp_ipam.api.urls import get_api_urls
 
 from . import CreateModelsMixin, PostDataMixin
 
@@ -488,3 +492,19 @@ class TestApi(
         host_address_32 = response.data["results"][0]["address"]
         self.assertEqual(host_address_128, "2001:db00::")
         self.assertEqual(host_address_32, "192.168.0.0")
+
+
+class TestApiUrls(TestCase):
+    def test_get_api_urls_without_api_views(self):
+        url_map = {url.name: url.callback for url in get_api_urls()}
+        self.assertEqual(url_map["hosts"], views.subnet_hosts)
+        self.assertEqual(url_map["subnet"], views.subnet)
+
+    def test_get_api_urls_with_partial_api_views(self):
+        def custom_subnet_hosts(request, *args, **kwargs):
+            pass
+
+        custom_views = SimpleNamespace(subnet_hosts=custom_subnet_hosts)
+        url_map = {url.name: url.callback for url in get_api_urls(custom_views)}
+        self.assertEqual(url_map["hosts"], custom_subnet_hosts)
+        self.assertEqual(url_map["subnet"], views.subnet)

--- a/openwisp_ipam/urls.py
+++ b/openwisp_ipam/urls.py
@@ -4,11 +4,12 @@ from .api import views as ipam_api_views
 from .api.urls import get_api_urls
 
 
-def get_urls(api_views):
+def get_urls(api_views=None):
     """
     returns:: all the urls of the openwisp-ipam module
     arguments::
-        api_views: location for getting API views
+        api_views: optional module or object providing custom API views,
+                   any view not found in it falls back to the default one
     """
     return [
         path(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #232.

## Description of Changes

`get_api_urls()` now works without `api_views`, and views not found there fall back to the default ones. So an extension only needs to define the views it wants to override. Same pattern as openwisp-users#554. Docs updated.